### PR TITLE
Update test_utils.py

### DIFF
--- a/app/db_manager/tests/test_utils.py
+++ b/app/db_manager/tests/test_utils.py
@@ -28,18 +28,5 @@ class DatabaseUploadTests(TestCase):
     def test_function_deletes_previous_companies(self):
         """Test that db is cleaned before the upload"""
         database_upload()
-        self.assertEqual(len(Company.objects.filter(name="Test")), 0)
-        self.assertEqual(len(Company.objects.filter(name="Undisclosed")), 0)
-
-
-
-
-
-
-
-
-
-
-
-
-
+        self.assertEqual(Company.objects.filter(name="Test").count(), 0)
+        self.assertEqual(Company.objects.filter(name="Undisclosed").count(), 0)


### PR DESCRIPTION
`len(Company.objects.filter(name="Test"))` will query all the rows utilizing python's memory and therefore, its much slower
`Company.objects.filter(name="Test").count()` will use SQL COUNT - hence it's much faster and efficient